### PR TITLE
Use @ for matrix multiplication

### DIFF
--- a/solver.py
+++ b/solver.py
@@ -70,7 +70,7 @@ class RummikubSolver:
         if maximise == 'tiles':
             obj = cp.Maximize(cp.sum(y))
         elif maximise == 'value':
-            obj = cp.Maximize(cp.sum(v*y))
+            obj = cp.Maximize(cp.sum(v @ y))
         else:
             print('Invalid maximise function')
             return 0, np.zeros(len(j)), np.zeros(len(i)),


### PR DESCRIPTION
Without this change, cvxpy issues a warning during solving:

```
/.../lib/python3.9/site-packages/cvxpy/expressions/expression.py:556: UserWarning:
This use of ``*`` has resulted in matrix multiplication.
Using ``*`` for matrix multiplication has been deprecated since CVXPY 1.1.
    Use ``*`` for matrix-scalar and vector-scalar multiplication.
    Use ``@`` for matrix-matrix and matrix-vector multiplication.
    Use ``multiply`` for elementwise multiplication.
This code path has been hit 1 times so far.

  warnings.warn(msg, UserWarning)
```